### PR TITLE
Fix user state transition

### DIFF
--- a/core/UserState.ts
+++ b/core/UserState.ts
@@ -285,8 +285,8 @@ class UserState {
                     attestation.graffiti,
                     attestation.overwriteGraffiti
                 )
+                return stateLeaves
             }
-            return stateLeaves
         }
         // If no matching state leaf, insert new one
         const newLeaf: IUserStateLeaf = {


### PR DESCRIPTION
- [x] Fix incorrect early return in `_updateUserStateLeaf`
- [x] Add test case in integration test: two attester attest to same user and perform user state transition

Thanks to @vivianjeng for reporting the bug